### PR TITLE
imx7d-pico.dtsi: Add a cpu-supply property

### DIFF
--- a/arch/arm/boot/dts/imx7d-pico.dtsi
+++ b/arch/arm/boot/dts/imx7d-pico.dtsi
@@ -263,6 +263,14 @@
 	};
 };
 
+&cpu0 {
+	cpu-supply = <&sw1a_reg>;
+};
+
+&cpu1 {
+	cpu-supply = <&sw1a_reg>;
+};
+
 &lcdif {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_lcdif>;


### PR DESCRIPTION
CPU frequency scaling driver fails to probe without a cpu-supply property on CPU dt node. This also causes imx_thermal driver probe to fail.