### PR TITLE
arm: dts: imx7d-pico: add board macro definitions for baseboard compatibility

### DIFF
--- a/arch/arm/boot/dts/imx7d-pico.dtsi
+++ b/arch/arm/boot/dts/imx7d-pico.dtsi
@@ -4,6 +4,80 @@
 
 
 #include "imx7d.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+
+/* external pins on PICO connector */
+#define PICO_EXT_GPIO_P24 gpio2 0
+#define PICO_EXT_GPIO_P25 gpio2 6
+#define PICO_EXT_GPIO_P26 gpio2 1
+#define PICO_EXT_GPIO_P28 gpio2 2
+#define PICO_EXT_GPIO_P30 gpio2 3
+#define PICO_EXT_GPIO_P32 gpio2 4
+#define PICO_EXT_GPIO_P34 gpio2 5
+#define PICO_EXT_GPIO_P42 gpio2 12
+#define PICO_EXT_GPIO_P44 gpio2 13
+#define PICO_EXT_GPIO_P48 gpio2 7
+
+#define PICO_DWARF_GPIO_DEFS()	\
+&gpio2 {													\
+	gpio-line-names =											\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "";									\
+															\
+	pinctrl-0 = <&pinctrl_gpio2>;										\
+}
+
+#define PICO_HOBBIT_GPIO_DEFS()	\
+&gpio2 {													\
+	gpio-line-names =											\
+		"GPIO_P24", "GPIO_P26", "GPIO_P28", "GPIO_P30", "", "GPIO_P34", "", "",	\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "";									\
+															\
+	pinctrl-0 = <&pinctrl_gpio2>;										\
+}
+
+#define PICO_NYMPH_GPIO_DEFS()	\
+&gpio2 {													\
+	gpio-line-names =											\
+		"", "", "GPIO_P28", "GPIO_P30", "GPIO_P32", "GPIO_P34", "", "",					\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "";									\
+															\
+	pinctrl-0 = <&pinctrl_gpio2>;										\
+}
+
+#define PICO_PI_GPIO_DEFS()	\
+&gpio2 {													\
+	gpio-line-names =											\
+		"GPIO_P24", "GPIO_P26", "GPIO_P28", "GPIO_P30", "", "GPIO_P34", "", "GPIO_P48",			\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "",									\
+		"", "", "", "", "", "", "", "";									\
+															\
+	pinctrl-0 = <&pinctrl_gpio2>;										\
+}
+
+#define PICO_PCIE pcie
+
+/* audio codec */
+#define PICO_AUDA_I2S_CHANNEL sai1
+#define PICO_AUDA_MUX_INT 3
+#define PICO_AUDA_MUX_EXT 3
+
+/* I2C bus */
+#define PICO_I2CA i2c1
+#define PICO_I2CB i2c4
+#define PICO_I2CC i2c2
+
+#define PICO_SPIA ecspi3
+
+#define PICO_CANA flexcan1
+#define PICO_CANB flexcan2
 
 / {
 	backlight: backlight {


### PR DESCRIPTION
## Problem

`imx7d-pico.dtsi` is missing the TechNexion-specific GPIO pin macros
(`PICO_EXT_GPIO_P*`, `PICO_*_GPIO_DEFS()`) and peripheral alias macros
(`PICO_I2CA/B/C`, `PICO_SPIA`, `PICO_CANA/B`, `PICO_PCIE`,
`PICO_AUDA_*`) that all baseboard DTSI files (e.g.
`baseboard_pico_pi.dtsi`) rely on.

Because these macros are absent from `imx7d-pico.dtsi`, any DTS that
tries to combine `imx7d-pico.dtsi` with a baseboard include fails to
compile.  As a result, the baseboard DTS files include
`imx7d-pico-qca.dtsi` instead — a QCA-specific file — even when the
board carries a Broadcom WiFi module.  This makes it impossible to build
a clean Broadcom-WiFi DTB without the unrelated QCA power-sequencing
setup also present.

## Fix

Move the macro definitions (already present verbatim in
`imx7d-pico-qca.dtsi`) into the common `imx7d-pico.dtsi`.  No
functional change for boards that already include `imx7d-pico-qca.dtsi`;
new DTSes that target Broadcom WiFi can now include `imx7d-pico.dtsi`
directly and add only the `mmc-pwrseq-simple` node they need.

## Testing

Compiled `imx7d-pico-pi-brcm.dts` (a new DTS that includes
`imx7d-pico.dtsi` + `baseboard_pico_pi.dtsi` and adds
`mmc-pwrseq-simple` for CLKO2) — previously this failed with undefined
macro errors; after this patch it compiles cleanly.

The resulting DTB was tested on PICO-IMX7D (i.MX7D) with AMPAK AP6335
(BCM4339) on USDHC2/SDIO.  With the 38.4 MHz reference clock now
supplied via `mmc-pwrseq-simple`, `brcmfmac.ko` initialises the chip
without the `HT Avail timeout (clkctl 0x50)` error and `wlan0` connects
successfully.

Companion PR: enables `CONFIG_BRCMFMAC=m` in `tn_imx_defconfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)